### PR TITLE
Issue 4: Support scheduled emails

### DIFF
--- a/src/MailerSendNetCore/Emails/Dtos/MailerSendEmailParameters.cs
+++ b/src/MailerSendNetCore/Emails/Dtos/MailerSendEmailParameters.cs
@@ -45,6 +45,9 @@ namespace MailerSendNetCore.Emails.Dtos
         [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
         public ICollection<string> Tags { get; set; }
 
+        [JsonProperty("send_at", NullValueHandling = NullValueHandling.Ignore)]
+        public long SendTime { get; set; } = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
         public MailerSendEmailParameters()
         {
             To = new List<MailerSendEmailRecipient>();
@@ -218,6 +221,14 @@ namespace MailerSendNetCore.Emails.Dtos
 
                 Personalizations.Add(item);
             }
+            return this;
+        }
+
+        public MailerSendEmailParameters WithSendTime(DateTime sendTime)
+        {
+            if (sendTime > DateTime.Now.AddHours(72))
+                throw new InvalidOperationException("The email send time cannot be more than 72 hours in the future");
+            SendTime = ((DateTimeOffset)sendTime).ToUnixTimeSeconds();
             return this;
         }
 

--- a/tests/MailserSend.UnitTests/Emails/MailerSendEmailParametersTests.cs
+++ b/tests/MailserSend.UnitTests/Emails/MailerSendEmailParametersTests.cs
@@ -29,6 +29,30 @@ namespace MailerSendNetCore.UnitTests.Emails
         }
 
         [Fact]
+        public void Test_WithSendTime_ShouldSetSendTime()
+        {
+            var instance = new MailerSendEmailParameters();
+            DateTime sendDateTime = DateTime.Now;
+            long sendUnixTime = ((DateTimeOffset)sendDateTime).ToUnixTimeSeconds();
+            instance.WithSendTime(sendDateTime);
+            instance.SendTime.Should().Be(sendUnixTime);
+        }
+
+        [Fact]
+        public void Test_WithSendTime_ShouldValidateSendTimeRange()
+        {
+            var instance = new MailerSendEmailParameters();
+
+            DateTime invalidSendDate = DateTime.Now.AddHours(73);
+            instance.WithTo("test@test.com");
+
+            Action action = () => instance.WithSendTime(invalidSendDate);
+            action.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("The email send time cannot be more than 72 hours in the future");
+        }
+
+        [Fact]
         public void Test_WithAttachment1_ShouldReplaceAttachmentCollection()
         {
             var instance = new MailerSendEmailParameters();


### PR DESCRIPTION
Issue: #4 
This PR adds support for scheduled emails, using the `send_at` parameter:  https://developers.mailersend.com/api/v1/email.html#send-an-email
