### PR TITLE
Update Microsoft.Extensions.* and Polly package versions

### DIFF
--- a/src/MailerSendNetCore/MailerSendNetCore.csproj
+++ b/src/MailerSendNetCore/MailerSendNetCore.csproj
@@ -27,14 +27,14 @@
  
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.6.6" />
+		<PackageReference Include="Polly" Version="8.7.0" />
 	</ItemGroup>
 
 </Project>

--- a/tests/MailserSend.UnitTests/MailserSend.UnitTests.csproj
+++ b/tests/MailserSend.UnitTests/MailserSend.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgraded Microsoft.Extensions.* dependencies from 10.0.8 to 10.0.9 and Polly from 8.6.6 to 8.7.0 in both MailerSendNetCore.csproj and MailserSend.UnitTests.csproj. This ensures the projects use the latest compatible versions.